### PR TITLE
Add permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint_markdown:
     name: Run markdown linter


### PR DESCRIPTION
Set explicit read-only contents permission to follow the principle of least privilege and fix CodeQL warnings.

Generated with Claude Code (https://claude.ai/code)